### PR TITLE
lower the msrv of sap to `1.85.0`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,14 +359,20 @@ impl Display for ParsingError {
             Self::InvalidOption { reason, offender } => {
                 let reserve = write!(f, "reason: {reason}");
                 if let Some(sentence) = offender {
-                    return write!(f, " at: {}", sentence.display());
+                    // `os_str_display` is stabilised in 1.87.0
+                    // https://github.com/rust-lang/rust/issues/120048
+                    // use `sentence.display()` if you don't care about rust <1.87.0
+                    return write!(f, " at: {}", String::from_utf8_lossy(sentence.as_bytes()));
                 }
 
                 reserve
             }
 
             Self::UnconsumedValue { value } => {
-                write!(f, "leftover value: {}", value.display())
+                // `os_str_display` is stabilised in 1.87.0
+                // https://github.com/rust-lang/rust/issues/120048
+                // use `value.display()` if you don't care about rust <1.87.0
+                write!(f, "leftover value: {}", String::from_utf8_lossy(value.as_bytes()))
             }
 
             Self::UnexpectedArg {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,7 @@ where
                 //
                 // `inherent_str_constructors` is not stabilised yet
                 // https://github.com/rust-lang/rust/issues/131114
+                // use `str::from_utf8(arg)` if you don't care about stable rust
                 let str_arg = match core::str::from_utf8(arg) {
                     Err(_e) => {
                         let err = ParsingError::InvalidString;
@@ -263,6 +264,7 @@ where
             //
             // `inherent_str_constructors` is not stabilised yet
             // https://github.com/rust-lang/rust/issues/131114
+            // use `str::from_utf8(arg)` if you don't care about stable rust
             let str_arg = match core::str::from_utf8(arg.as_encoded_bytes()) {
                 Err(_e) => {
                     let err = ParsingError::InvalidString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,8 @@ where
             //
             // `inherent_str_constructors` is not stabilised yet
             // https://github.com/rust-lang/rust/issues/131114
-            // use `str::from_utf8(arg)` if you don't care about stable rust
+            // use `str::from_utf8(arg.as_encoded_bytes())`
+            // if you don't care about stable rust
             let str_arg = match core::str::from_utf8(arg.as_encoded_bytes()) {
                 Err(_e) => {
                     let err = ParsingError::InvalidString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,8 @@ where
                 // can be as bright as Proxima Centauri
                 // or as dark as Sagittarius A
                 //
-                // `str::from_utf8` is stabilised in 1.87.0
+                // `str::from_utf8` is not stabilised yet
+                // https://github.com/rust-lang/rust/issues/131114
                 let str_arg = match core::str::from_utf8(arg) {
                     Err(_e) => {
                         let err = ParsingError::InvalidString;
@@ -260,7 +261,8 @@ where
             // however i am not sure of the user's
             // eternal glory and shine
             //
-            // `str::from_utf8` is stabilised in 1.87.0
+            // `str::from_utf8` is not stabilised yet
+            // https://github.com/rust-lang/rust/issues/131114
             let str_arg = match core::str::from_utf8(arg.as_encoded_bytes()) {
                 Err(_e) => {
                     let err = ParsingError::InvalidString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,8 +223,8 @@ where
                 // however the user
                 // can be as bright as Proxima Centauri
                 // or as dark as Sagittarius A
-                // TODO: switch to `str::from_utf8` when stabilized
-                // https://github.com/rust-lang/rust/issues/131114
+                //
+                // `str::from_utf8` is stabilised in 1.87.0
                 let str_arg = match core::str::from_utf8(arg) {
                     Err(_e) => {
                         let err = ParsingError::InvalidString;
@@ -259,8 +259,8 @@ where
             // might not be needed,
             // however i am not sure of the user's
             // eternal glory and shine
-            // TODO: switch to `str::from_utf8` when stabilized
-            // https://github.com/rust-lang/rust/issues/131114
+            //
+            // `str::from_utf8` is stabilised in 1.87.0
             let str_arg = match core::str::from_utf8(arg.as_encoded_bytes()) {
                 Err(_e) => {
                     let err = ParsingError::InvalidString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,9 @@ where
                 // however the user
                 // can be as bright as Proxima Centauri
                 // or as dark as Sagittarius A
-                let str_arg = match str::from_utf8(arg) {
+                // TODO: switch to `str::from_utf8` when stabilized
+                // https://github.com/rust-lang/rust/issues/131114
+                let str_arg = match core::str::from_utf8(arg) {
                     Err(_e) => {
                         let err = ParsingError::InvalidString;
                         return Err(err);
@@ -257,7 +259,9 @@ where
             // might not be needed,
             // however i am not sure of the user's
             // eternal glory and shine
-            let str_arg = match str::from_utf8(arg.as_encoded_bytes()) {
+            // TODO: switch to `str::from_utf8` when stabilized
+            // https://github.com/rust-lang/rust/issues/131114
+            let str_arg = match core::str::from_utf8(arg.as_encoded_bytes()) {
                 Err(_e) => {
                     let err = ParsingError::InvalidString;
                     return Err(err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ where
                 // can be as bright as Proxima Centauri
                 // or as dark as Sagittarius A
                 //
-                // `str::from_utf8` is not stabilised yet
+                // `inherent_str_constructors` is not stabilised yet
                 // https://github.com/rust-lang/rust/issues/131114
                 let str_arg = match core::str::from_utf8(arg) {
                     Err(_e) => {
@@ -261,7 +261,7 @@ where
             // however i am not sure of the user's
             // eternal glory and shine
             //
-            // `str::from_utf8` is not stabilised yet
+            // `inherent_str_constructors` is not stabilised yet
             // https://github.com/rust-lang/rust/issues/131114
             let str_arg = match core::str::from_utf8(arg.as_encoded_bytes()) {
                 Err(_e) => {


### PR DESCRIPTION
this PR replaces `str::from_utf8(bytes)` (https://github.com/rust-lang/rust/issues/131114, still unstable) with `core::str::from_utf8(bytes)` and `OsStr::display(s)` (https://github.com/rust-lang/rust/issues/120048, stabilised in 1.87.0) with `String::from_utf8_lossy(s.as_bytes())`, pushing the msrv down to the earliest that supports the 2024 edition (1.85.0)

there are comments next to each instance with the feature and link to its issue, as well as the old way it was done in case you want to go back to that